### PR TITLE
Switch from ATOMIC_USIZE_INIT to AtomicUsize::new(0)

### DIFF
--- a/sys/src/macros.rs
+++ b/sys/src/macros.rs
@@ -206,7 +206,7 @@ macro_rules! nvapi {
     ) => {
         $(#[$meta])*
         pub unsafe fn $fn($($arg: $arg_ty),*) -> $ret {
-            static CACHE: ::std::sync::atomic::AtomicUsize = ::std::sync::atomic::ATOMIC_USIZE_INIT;
+            static CACHE: ::std::sync::atomic::AtomicUsize = ::std::sync::atomic::AtomicUsize::new(0);
 
             match ::nvapi::query_interface(::nvid::Api::$fn.id(), &CACHE) {
                 Ok(ptr) => ::std::mem::transmute::<_, extern "C" fn($($arg: $arg_ty),*) -> $ret>(ptr)($($arg),*),

--- a/sys/src/nvapi.rs
+++ b/sys/src/nvapi.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::os::raw::c_void;
 use status::{Status, NvAPI_Status};
 use types;
@@ -12,7 +12,7 @@ pub const LIBRARY_NAME: &'static [u8; 12] = b"nvapi64.dll\0";
 
 pub const FN_NAME: &'static [u8; 21] = b"nvapi_QueryInterface\0";
 
-static QUERY_INTERFACE_CACHE: AtomicUsize = ATOMIC_USIZE_INIT;
+static QUERY_INTERFACE_CACHE: AtomicUsize = AtomicUsize::new(0);
 
 pub unsafe fn set_query_interface(ptr: QueryInterfaceFn) {
     QUERY_INTERFACE_CACHE.store(ptr as usize, Ordering::Relaxed);


### PR DESCRIPTION
AtomicUsize::new(0)'s constness was stabilized in Rust 1.24.0