### PR TITLE
Laptop and delta fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nvapi"
-version = "0.3.0" # keep in sync with html_root_url
+version = "0.3.1" # keep in sync with html_root_url
 authors = ["arcnmx"]
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nvapi"
-version = "0.2.0" # keep in sync with html_root_url
+version = "0.3.0" # keep in sync with html_root_url
 authors = ["arcnmx"]
 edition = "2021"
 
@@ -13,7 +13,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-nvapi-sys = { version = "0.2", path = "sys", default-features = false }
+nvapi-sys = { version = "0.3", path = "sys", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 i2c = { version = "0.1", optional = true }
 log = "0.4"

--- a/hi/Cargo.toml
+++ b/hi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nvapi-hi"
-version = "0.3.0" # keep in sync with html_root_url
+version = "0.3.1" # keep in sync with html_root_url
 authors = ["arcnmx"]
 edition = "2021"
 

--- a/hi/Cargo.toml
+++ b/hi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nvapi-hi"
-version = "0.2.0" # keep in sync with html_root_url
+version = "0.3.0" # keep in sync with html_root_url
 authors = ["arcnmx"]
 edition = "2021"
 
@@ -13,11 +13,11 @@ readme = "../README.md"
 license = "MIT"
 
 [dependencies]
-nvapi = { version = "^0.2.0", path = "../", default-features = false }
+nvapi = { version = "^0.3.0", path = "../", default-features = false }
 serde = { version = "^1.0.0", optional = true }
 serde_derive = { version = "^1.0.0", optional = true }
 once_cell = "^1.12.0"
 
 [features]
-serde_types = ["serde", "serde_derive", "nvapi/serde_types"]
+serde_types = ["serde", "serde_derive", "nvapi/serde"]
 default = ["serde_types"]

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -408,7 +408,7 @@ impl PhysicalGpu {
         data.mask = info.mask.mask;
         for (i, delta) in clocks {
             trace!("gpu.set_vfp_table({:?}, {:?})", i, delta);
-            data.points[i].freqDeltaKHz = delta.0;
+            data.points[i].freqDeltaKHz = delta.0 / 2;
             data.mask.set_bit(i);
         }
         /*for (i, delta) in memory {

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -388,20 +388,23 @@ impl PhysicalGpu {
         })
     }
 
-    pub fn vfp_table(&self, info: &VfpInfo) -> crate::Result<crate::clock::ClockTable> {
+    pub fn vfp_table_raw(&self, info: &VfpInfo) -> Result<clock::private::NV_GPU_CLOCK_CLIENT_CLK_VF_POINTS_CONTROL,crate::Error> {
         trace!("gpu.vfp_table({:?})", info);
         let mut data = clock::private::NV_GPU_CLOCK_CLIENT_CLK_VF_POINTS_CONTROL::default();
         data.mask = info.mask.mask;
 
         unsafe {
-            nvcall!(NvAPI_GPU_ClockClientClkVfPointsGetControl@get{data}(self.0) => err)
-                .and_then(|raw| crate::clock::ClockTable::from_raw(&raw, info))
+            nvcall!(NvAPI_GPU_ClockClientClkVfPointsGetControl@get{data}(self.0) => err)       
         }
+    }
+    
+    pub fn vfp_table(&self, info: &VfpInfo) -> crate::Result<crate::clock::ClockTable> {
+        self.vfp_table_raw(info).and_then(|raw| crate::clock::ClockTable::from_raw(&raw, info))
     }
 
     pub fn set_vfp_table<I: Iterator<Item=(usize, Kilohertz2Delta)>, M: Iterator<Item=(usize, Kilohertz2Delta)>>(&self, info: &VfpInfo, clocks: I, memory: M) -> crate::NvapiResult<()> {
         trace!("gpu.set_vfp_table({:?})", info);
-        let mut data = clock::private::NV_GPU_CLOCK_CLIENT_CLK_VF_POINTS_CONTROL::default();
+        let mut data = self.vfp_table_raw(info).unwrap();
         data.mask = info.mask.mask;
         for (i, delta) in clocks {
             trace!("gpu.set_vfp_table({:?}, {:?})", i, delta);
@@ -412,7 +415,7 @@ impl PhysicalGpu {
             data.memFilled[i] = 1;
             data.memDeltas[i] = delta.0;
         }*/
-
+        
         unsafe {
             nvcall!(NvAPI_GPU_ClockClientClkVfPointsSetControl(self.0, &data))
         }

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nvapi-sys"
-version = "0.3.0" # keep in sync with html_root_url
+version = "0.3.1" # keep in sync with html_root_url
 authors = ["arcnmx"]
 edition = "2021"
 

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nvapi-sys"
-version = "0.2.0" # keep in sync with html_root_url
+version = "0.3.0" # keep in sync with html_root_url
 authors = ["arcnmx"]
 edition = "2021"
 

--- a/sys/src/gpu/clock.rs
+++ b/sys/src/gpu/clock.rs
@@ -249,7 +249,9 @@ pub mod private {
             NV_PERF_CLIENT_LIMIT_ID_GPU / Gpu = 0,
             NV_PERF_CLIENT_LIMIT_ID_GPU_UNKNOWN / GpuUnknown = 1,
             NV_PERF_CLIENT_LIMIT_ID_MEMORY / Memory = 2,
-            NV_PERF_CLIENT_LIMIT_ID_MEMORY_UNKOWN / MemoryUnknown = 3,
+            NV_PERF_CLIENT_LIMIT_ID_MEMORY_UNKNOWN / MemoryUnknown = 3,
+            NV_PERF_CLIENT_LIMIT_ID_UNKNOWN / Unknown = 4,
+            NV_PERF_CLIENT_LIMIT_ID_UNKNOWN_2 / Unknown_2 = 5,
             NV_PERF_CLIENT_LIMIT_ID_VOLTAGE / Voltage = 6,
         }
     }

--- a/sys/src/status.rs
+++ b/sys/src/status.rs
@@ -7,6 +7,8 @@ nvenum! {
     /// NvAPI Status Values
     ///
     /// All NvAPI functions return one of these codes.
+    /// 
+    /// https://docs.nvidia.com/gameworks/content/gameworkslibrary/coresdk/nvapi/group__nvapistatus.html
     pub enum NvAPI_Status / Status {
         /// Success. Request is completed.
         NVAPI_OK / Ok = 0,
@@ -278,6 +280,29 @@ nvenum! {
         NVAPI_INVALID_DIRECT_MODE_DISPLAY / InvalidDirectModeDisplay = -216,
         /// GPU is in debug mode, OC is NOT allowed.
         NVAPI_GPU_IN_DEBUG_MODE / GpuInDebugMode = -217,
+        NVAPI_D3D_CONTEXT_NOT_FOUND / D3DContextNotFound = -218,
+        NVAPI_STEREO_VERSION_MISMATCH / StereoVersionMismatch = -219,
+        NVAPI_GPU_NOT_POWERED / GpuNotPowered = -220,
+        NVAPI_ERROR_DRIVER_RELOAD_IN_PROGRESS / DriverReloadInProgress = -221,
+        NVAPI_WAIT_FOR_HW_RESOURCE / WaitForHwResource = -222,
+        NVAPI_REQUIRE_FURTHER_HDCP_ACTION / RequireFurtherHdcpAction = -223,
+        NVAPI_DISPLAY_MUX_TRANSITION_FAILED / DisplayMuxTransitionFailed = -224,
+        NVAPI_INVALID_DSC_VERSION / InvalidDscVersion = -225,
+        NVAPI_INVALID_DSC_SLICECOUNT / InvalidDscSlicecount = -226,
+        NVAPI_INVALID_DSC_OUTPUT_BPP / InvalidDscOutputBpp = -227,
+        NVAPI_FAILED_TO_LOAD_FROM_DRIVER_STORE / FailedToLoadFromDriverStore = -228,
+        NVAPI_NO_VULKAN / NoVulkan = -229,
+        NVAPI_REQUEST_PENDING / RequestPending = -230,
+        NVAPI_RESOURCE_IN_USE / ResourceInUse = -231,
+        NVAPI_INVALID_IMAGE / InvalidImage = -232,
+        NVAPI_INVALID_PTX / InvalidPtx = -233,
+        NVAPI_NVLINK_UNCORRECTABLE / NvlinkUncorrectable = -234,
+        NVAPI_JIT_COMPILER_NOT_FOUND / JitCompilerNotFound = -235,
+        NVAPI_INVALID_SOURCE / InvalidSource = -236,
+        NVAPI_ILLEGAL_INSTRUCTION / IllegalInstruction = -237,
+        NVAPI_INVALID_PC / InvalidPc = -238,
+        NVAPI_LAUNCH_FAILED / LaunchFailed = -239,
+        NVAPI_NOT_PERMITTED / NotPermitted = -240,
     }
 }
 


### PR DESCRIPTION
Fixed that `set_vfp_table` was setting twice the deltas.

Also, fixes that are needed to run on my 3070Ti Mobile:
 - Use system VFP table as base, otherwise VF curve applying fails with `NVAPI_ERROR`
 - Defined more error types, for example, `NVAPI_GPU_NOT_POWERED` - appears when discrete laptop GPU isn't powered at the moment instead of returning generic `NVAPI_ERROR`
