### PR TITLE
Export nvapi_sys macro

### DIFF
--- a/sys/src/dispcontrol.rs
+++ b/sys/src/dispcontrol.rs
@@ -2,7 +2,7 @@ use std::os::raw::c_char;
 use crate::status::NvAPI_Status;
 use crate::handles;
 
-nvapi! {
+nvapi_fn! {
     pub type EnumNvidiaDisplayHandleFn = extern "C" fn(thisEnum: u32, pNvDispHandle: *mut handles::NvDisplayHandle) -> NvAPI_Status;
 
     /// This function returns the handle of the NVIDIA display specified by the enum
@@ -14,7 +14,7 @@ nvapi! {
     pub unsafe fn NvAPI_EnumNvidiaDisplayHandle;
 }
 
-nvapi! {
+nvapi_fn! {
     pub type EnumNvidiaUnAttachedDisplayHandleFn = extern "C" fn(thisEnum: u32, pNvUnAttachedDispHandle: *mut handles::NvUnAttachedDisplayHandle) -> NvAPI_Status;
 
     /// This function returns the handle of the NVIDIA unattached display specified by the enum
@@ -26,7 +26,7 @@ nvapi! {
     pub unsafe fn NvAPI_EnumNvidiaUnAttachedDisplayHandle;
 }
 
-nvapi! {
+nvapi_fn! {
     pub type GetAssociatedNvidiaDisplayHandleFn = extern "C" fn(szDisplayName: *const c_char, pNvDispHandle: *mut handles::NvDisplayHandle) -> NvAPI_Status;
 
     /// This function returns the handle of the NVIDIA display that is associated
@@ -34,7 +34,7 @@ nvapi! {
     pub unsafe fn NvAPI_GetAssociatedNvidiaDisplayHandle;
 }
 
-nvapi! {
+nvapi_fn! {
     pub type DISP_GetAssociatedUnAttachedNvidiaDisplayHandleFn = extern "C" fn(szDisplayName: *const c_char, pNvUnAttachedDispHandle: *mut handles::NvDisplayHandle) -> NvAPI_Status;
 
     /// This function returns the handle of an unattached NVIDIA display that is

--- a/sys/src/driverapi.rs
+++ b/sys/src/driverapi.rs
@@ -2,7 +2,7 @@ use crate::status::NvAPI_Status;
 use crate::types::NvAPI_ShortString;
 use crate::handles;
 
-nvapi! {
+nvapi_fn! {
     pub type SYS_GetDriverAndBranchVersionFn = extern "C" fn(pDriverVersion: *mut u32, szBuildBranchString: *mut NvAPI_ShortString) -> NvAPI_Status;
 
     /// This API returns display driver version and driver-branch string.
@@ -54,7 +54,7 @@ nvversion! { NV_DISPLAY_DRIVER_MEMORY_INFO_VER_2(NV_DISPLAY_DRIVER_MEMORY_INFO_V
 nvversion! { NV_DISPLAY_DRIVER_MEMORY_INFO_VER_3(NV_DISPLAY_DRIVER_MEMORY_INFO_V3 = 4 * 8, 3) }
 nvversion! { NV_DISPLAY_DRIVER_MEMORY_INFO_VER = NV_DISPLAY_DRIVER_MEMORY_INFO_VER_3 }
 
-nvapi! {
+nvapi_fn! {
     pub type GPU_GetMemoryInfoFn = extern "C" fn(hPhysicalGpu: handles::NvPhysicalGpuHandle, pMemoryInfo: *mut NV_DISPLAY_DRIVER_MEMORY_INFO) -> NvAPI_Status;
 
     /// This function retrieves the available driver memory footprint for the specified GPU.
@@ -67,7 +67,7 @@ pub mod private {
     use crate::status::NvAPI_Status;
     use crate::handles;
 
-    nvapi! {
+    nvapi_fn! {
         /// This has a different offset than the NvAPI_GPU_GetMemoryInfo function despite both returning the same struct
         pub unsafe fn NvAPI_GetDisplayDriverMemoryInfo(hPhysicalGpu: handles::NvPhysicalGpuHandle, pMemoryInfo: *mut super::NV_DISPLAY_DRIVER_MEMORY_INFO) -> NvAPI_Status;
     }

--- a/sys/src/dx.rs
+++ b/sys/src/dx.rs
@@ -5,7 +5,7 @@ use crate::status::NvAPI_Status;
 nv_declare_handle! { NVDX_ObjectHandle }
 pub const NVDX_OBJECT_NONE: NVDX_ObjectHandle = NVDX_ObjectHandle(0 as *const _);
 
-nvapi! {
+nvapi_fn! {
     pub type D3D_GetObjectHandleForResourceFn = extern "C" fn(pDevice: *const IUnknown, pResource: *const IUnknown, pHandle: *mut NVDX_ObjectHandle) -> NvAPI_Status;
 
     /// This API gets a handle to a resource.

--- a/sys/src/gpu/clock.rs
+++ b/sys/src/gpu/clock.rs
@@ -79,7 +79,7 @@ nvstruct! {
     }
 }
 
-nvapi! {
+nvapi_fn! {
     pub type GPU_GetAllClockFrequenciesFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pClkFreqs: *mut NV_GPU_CLOCK_FREQUENCIES) -> NvAPI_Status;
 
     /// This function retrieves the NV_GPU_CLOCK_FREQUENCIES structure for the specified physical GPU.
@@ -126,7 +126,7 @@ pub mod private {
 
     pub type NV_USAGES_INFO = NV_USAGES_INFO_V1;
 
-    nvapi! {
+    nvapi_fn! {
         pub type GPU_GetUsagesFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pUsagesInfo: *mut NV_USAGES_INFO) -> NvAPI_Status;
 
         /// Undocumented function. Probably deprecated and replaced with NvAPI_GPU_GetDynamicPstatesInfoEx()
@@ -145,7 +145,7 @@ pub mod private {
 
     pub type NV_CLOCKS_INFO = NV_CLOCKS_INFO_V1;
 
-    nvapi! {
+    nvapi_fn! {
         pub type GPU_GetAllClocksFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pClocksInfo: *mut NV_CLOCKS_INFO) -> NvAPI_Status;
 
         /// Undocumented function. Probably deprecated and replaced with NvAPI_GPU_GetAllClockFrequencies()
@@ -193,12 +193,12 @@ pub mod private {
 
     pub type NV_GPU_CLOCK_CLIENT_CLK_VF_POINTS_CONTROL = NV_GPU_CLOCK_CLIENT_CLK_VF_POINTS_CONTROL_V1;
 
-    nvapi! {
+    nvapi_fn! {
         /// Pascal only
         pub unsafe fn NvAPI_GPU_ClockClientClkVfPointsGetControl(hPhysicalGPU: NvPhysicalGpuHandle, pClockTable: *mut NV_GPU_CLOCK_CLIENT_CLK_VF_POINTS_CONTROL) -> NvAPI_Status;
     }
 
-    nvapi! {
+    nvapi_fn! {
         /// Pascal only
         pub unsafe fn NvAPI_GPU_ClockClientClkVfPointsSetControl(hPhysicalGPU: NvPhysicalGpuHandle, pClockTable: *const NV_GPU_CLOCK_CLIENT_CLK_VF_POINTS_CONTROL) -> NvAPI_Status;
     }
@@ -240,7 +240,7 @@ pub mod private {
 
     pub type NV_GPU_CLOCK_CLIENT_CLK_DOMAINS_INFO = NV_GPU_CLOCK_CLIENT_CLK_DOMAINS_INFO_V1;
 
-    nvapi! {
+    nvapi_fn! {
         /// Pascal only
         pub unsafe fn NvAPI_GPU_ClockClientClkDomainsGetInfo(hPhysicalGPU: NvPhysicalGpuHandle, pClockRanges: *mut NV_GPU_CLOCK_CLIENT_CLK_DOMAINS_INFO) -> NvAPI_Status;
     }
@@ -271,7 +271,7 @@ pub mod private {
 
     pub type NV_GPU_CLOCK_CLIENT_CLK_VF_POINTS_INFO = NV_GPU_CLOCK_CLIENT_CLK_VF_POINTS_INFO_V1;
 
-    nvapi! {
+    nvapi_fn! {
         /// Pascal only
         pub unsafe fn NvAPI_GPU_ClockClientClkVfPointsGetInfo(hPhysicalGPU: NvPhysicalGpuHandle, pClockMasks: *mut NV_GPU_CLOCK_CLIENT_CLK_VF_POINTS_INFO) -> NvAPI_Status;
     }
@@ -309,12 +309,12 @@ pub mod private {
     nvversion! { NV_GPU_PERF_CLIENT_LIMITS_VER_2(NV_GPU_PERF_CLIENT_LIMITS_V2 = 0x30c, 2) }
     nvversion! { NV_GPU_PERF_CLIENT_LIMITS_VER = NV_GPU_PERF_CLIENT_LIMITS_VER_2 }
 
-    nvapi! {
+    nvapi_fn! {
         /// Pascal only
         pub unsafe fn NvAPI_GPU_PerfClientLimitsGetStatus(hPhysicalGPU: NvPhysicalGpuHandle, pClockLocks: *mut NV_GPU_PERF_CLIENT_LIMITS) -> NvAPI_Status;
     }
 
-    nvapi! {
+    nvapi_fn! {
         /// Pascal only
         pub unsafe fn NvAPI_GPU_PerfClientLimitsSetStatus(hPhysicalGPU: NvPhysicalGpuHandle, pClockLocks: *const NV_GPU_PERF_CLIENT_LIMITS) -> NvAPI_Status;
     }

--- a/sys/src/gpu/cooler.rs
+++ b/sys/src/gpu/cooler.rs
@@ -1,7 +1,7 @@
 use crate::status::NvAPI_Status;
 use crate::handles::NvPhysicalGpuHandle;
 
-nvapi! {
+nvapi_fn! {
     pub type GPU_GetTachReadingFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pValue: *mut u32) -> NvAPI_Status;
 
     /// This API retrieves the fan speed tachometer reading for the specified physical GPU.
@@ -165,7 +165,7 @@ pub mod private {
 
     pub type NV_GPU_COOLER_SETTINGS = NV_GPU_COOLER_SETTINGS_V1;
 
-    nvapi! {
+    nvapi_fn! {
         pub type GPU_GetCoolerSettingsFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, coolerIndex: u32, pCoolerInfo: *mut NV_GPU_COOLER_SETTINGS) -> NvAPI_Status;
 
         /// Undocumented function.
@@ -200,7 +200,7 @@ pub mod private {
 
     pub type NV_GPU_SETCOOLER_LEVEL = NV_GPU_SETCOOLER_LEVEL_V1;
 
-    nvapi! {
+    nvapi_fn! {
         pub type GPU_SetCoolerLevelsFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, coolerIndex: u32, pCoolerLevels: *const NV_GPU_SETCOOLER_LEVEL) -> NvAPI_Status;
 
         /// Undocumented function.
@@ -218,7 +218,7 @@ pub mod private {
         pub unsafe fn NvAPI_GPU_SetCoolerLevels;
     }
 
-    nvapi! {
+    nvapi_fn! {
         pub type GPU_RestoreCoolerSettingsFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, coolerIndex: *const u32, coolerCount: u32) -> NvAPI_Status;
 
         /// Undocumented function.
@@ -258,7 +258,7 @@ pub mod private {
 
     pub type NV_GPU_COOLER_POLICY_TABLE = NV_GPU_COOLER_POLICY_TABLE_V1;
 
-    nvapi! {
+    nvapi_fn! {
         pub type GPU_GetCoolerPolicyTableFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, coolerIndex: u32, pCoolerTable: *mut NV_GPU_COOLER_POLICY_TABLE, count: *mut u32) -> NvAPI_Status;
 
         /// Undocumented function.
@@ -266,7 +266,7 @@ pub mod private {
         pub unsafe fn NvAPI_GPU_GetCoolerPolicyTable;
     }
 
-    nvapi! {
+    nvapi_fn! {
         pub type GPU_SetCoolerPolicyTableFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, coolerIndex: u32, pCoolerTable: *const NV_GPU_COOLER_POLICY_TABLE, count: u32) -> NvAPI_Status;
 
         /// Undocumented function.
@@ -278,7 +278,7 @@ pub mod private {
         pub unsafe fn NvAPI_GPU_SetCoolerPolicyTable;
     }
 
-    nvapi! {
+    nvapi_fn! {
         pub type GPU_RestoreCoolerPolicyTableFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, coolerIndex: *const u32, coolerCount: u32, policy: NV_COOLER_POLICY) -> NvAPI_Status;
 
         /// Undocumented function.

--- a/sys/src/gpu/display.rs
+++ b/sys/src/gpu/display.rs
@@ -84,7 +84,7 @@ nvversion! { NV_GPU_DISPLAYIDS_VER1(NV_GPU_DISPLAYIDS = 4 * 4, 1) }
 nvversion! { NV_GPU_DISPLAYIDS_VER2(NV_GPU_DISPLAYIDS = 4 * 4, 3) }
 nvversion! { NV_GPU_DISPLAYIDS_VER = NV_GPU_DISPLAYIDS_VER2 }
 
-nvapi! {
+nvapi_fn! {
     pub type GPU_GetConnectedDisplayIds = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pDisplayIds: *mut NV_GPU_DISPLAYIDS, pDisplayIdCount: *mut u32, flags: NV_GPU_CONNECTED_IDS_FLAG) -> NvAPI_Status;
 
     /// Due to space limitation NvAPI_GPU_GetConnectedOutputs can return maximum 32 devices, but
@@ -109,7 +109,7 @@ nvapi! {
     pub unsafe fn NvAPI_GPU_GetConnectedDisplayIds;
 }
 
-nvapi! {
+nvapi_fn! {
     pub type GPU_GetAllDisplayIds = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pDisplayIds: *mut NV_GPU_DISPLAYIDS, pDisplayIdCount: *mut u32) -> NvAPI_Status;
 
     /// This API returns display IDs for all possible outputs on the GPU.

--- a/sys/src/gpu/mod.rs
+++ b/sys/src/gpu/mod.rs
@@ -34,7 +34,7 @@ pub mod power;
 
 pub mod display;
 
-nvapi! {
+nvapi_fn! {
     pub type EnumPhysicalGPUsFn = extern "C" fn(nvGPUHandle: *mut [NvPhysicalGpuHandle; types::NVAPI_MAX_PHYSICAL_GPUS], pGpuCount: *mut u32) -> NvAPI_Status;
 
     /// This function returns an array of physical GPU handles.
@@ -56,14 +56,14 @@ nvapi! {
     pub unsafe fn NvAPI_EnumPhysicalGPUs;
 }
 
-nvapi! {
+nvapi_fn! {
     pub type GPU_GetFullNameFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, szName: *mut types::NvAPI_ShortString) -> NvAPI_Status;
 
     /// This function retrieves the full GPU name as an ASCII string - for example, "Quadro FX 1400".
     pub unsafe fn NvAPI_GPU_GetFullName;
 }
 
-nvapi! {
+nvapi_fn! {
     pub type GPU_GetPhysicalFrameBufferSizeFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pSize: *mut u32) -> NvAPI_Status;
 
     /// This function returns the physical size of framebuffer in KB.  This does NOT include any
@@ -71,7 +71,7 @@ nvapi! {
     pub unsafe fn NvAPI_GPU_GetPhysicalFrameBufferSize;
 }
 
-nvapi! {
+nvapi_fn! {
     pub type GPU_GetVbiosVersionStringFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, szBiosRevision: *mut types::NvAPI_ShortString) -> NvAPI_Status;
 
     /// This function returns the full video BIOS version string in the form of xx.xx.xx.xx.yy where
@@ -80,7 +80,7 @@ nvapi! {
     pub unsafe fn NvAPI_GPU_GetVbiosVersionString;
 }
 
-nvapi! {
+nvapi_fn! {
     pub type GPU_GetPCIIdentifiersFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pDeviceId: *mut u32, pSubSystemId: *mut u32, pRevisionId: *mut u32, pExtDeviceId: *mut u32) -> NvAPI_Status;
 
     /// This function returns the PCI identifiers associated with this GPU.
@@ -100,14 +100,14 @@ nvenum_display! {
     SystemType => _
 }
 
-nvapi! {
+nvapi_fn! {
     pub type GPU_GetSystemTypeFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pSystemType: *mut NV_SYSTEM_TYPE) -> NvAPI_Status;
 
     /// This function identifies whether the GPU is a notebook GPU or a desktop GPU.
     pub unsafe fn NvAPI_GPU_GetSystemType;
 }
 
-nvapi! {
+nvapi_fn! {
     pub type GPU_GetShaderSubPipeCountFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pCount: *mut u32) -> NvAPI_Status;
 
     /// This function retrieves the number of Shader SubPipes on the GPU
@@ -115,7 +115,7 @@ nvapi! {
     pub unsafe fn NvAPI_GPU_GetShaderSubPipeCount;
 }
 
-nvapi! {
+nvapi_fn! {
     pub type GPU_GetGpuCoreCountFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pCount: *mut u32) -> NvAPI_Status;
 
     /// Retrieves the total number of cores defined for a GPU.
@@ -137,7 +137,7 @@ nvversion! { NV_BOARD_INFO_VER = NV_BOARD_INFO_VER1 }
 
 pub type NV_BOARD_INFO = NV_BOARD_INFO_V1;
 
-nvapi! {
+nvapi_fn! {
     /// This API Retrieves the Board information (a unique GPU Board Serial Number) stored in the InfoROM.
     pub unsafe fn NvAPI_GPU_GetBoardInfo(hPhysicalGpu: NvPhysicalGpuHandle, pBoardInfo: *mut NV_BOARD_INFO) -> NvAPI_Status;
 }
@@ -157,7 +157,7 @@ nvbits! {
     }
 }
 
-nvapi! {
+nvapi_fn! {
     /// This function retrieves reasons for the current performance decrease.
     pub unsafe fn NvAPI_GPU_GetPerfDecreaseInfo(hPhysicalGpu: NvPhysicalGpuHandle, pPerfDecrInfo: *mut NVAPI_GPU_PERF_DECREASE) -> NvAPI_Status;
 }
@@ -170,7 +170,7 @@ pub mod private {
 
     pub const NVAPI_MAX_PROCESSES: usize = 128;
 
-    nvapi! {
+    nvapi_fn! {
         pub type GPU_GetShaderPipeCountFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pCount: *mut u32) -> NvAPI_Status;
 
         pub unsafe fn NvAPI_GPU_GetShaderPipeCount;
@@ -197,7 +197,7 @@ pub mod private {
         RamType => _
     }
 
-    nvapi! {
+    nvapi_fn! {
         pub type GPU_GetRamTypeFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pMemType: *mut NV_GPU_RAM_TYPE) -> NvAPI_Status;
 
         /// Undocumented function.
@@ -226,21 +226,21 @@ pub mod private {
         RamMaker => _
     }
 
-    nvapi! {
+    nvapi_fn! {
         pub type GPU_GetRamMakerFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pRamMaker: *mut NV_GPU_RAM_MAKER) -> NvAPI_Status;
 
         /// Undocumented function.
         pub unsafe fn NvAPI_GPU_GetRamMaker;
     }
 
-    nvapi! {
+    nvapi_fn! {
         pub type GPU_GetRamBusWidthFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pRamBusWidth: *mut u32) -> NvAPI_Status;
 
         /// Undocumented function.
         pub unsafe fn NvAPI_GPU_GetRamBusWidth;
     }
 
-    nvapi! {
+    nvapi_fn! {
         pub type GPU_GetRamBankCountFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pRamBankCount: *mut u32) -> NvAPI_Status;
 
         /// Undocumented function.
@@ -272,14 +272,14 @@ pub mod private {
         }
     }
 
-    nvapi! {
+    nvapi_fn! {
         pub type GPU_GetFoundryFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pFoundry: *mut NV_GPU_FOUNDRY) -> NvAPI_Status;
 
         /// Undocumented function.
         pub unsafe fn NvAPI_GPU_GetFoundry;
     }
 
-    nvapi! {
+    nvapi_fn! {
         pub unsafe fn NvAPI_GPU_GetFBWidthAndLocation(hPhysicalGpu: NvPhysicalGpuHandle, pWidth: *mut u32, pLocation: *mut u32) -> NvAPI_Status;
     }
 
@@ -318,19 +318,19 @@ pub mod private {
         }
     }
 
-    nvapi! {
+    nvapi_fn! {
         pub unsafe fn NvAPI_GetGPUIDFromPhysicalGPU(hPhysicalGpu: NvPhysicalGpuHandle, gpuid: *mut u32) -> NvAPI_Status;
     }
 
-    nvapi! {
+    nvapi_fn! {
         pub unsafe fn NvAPI_GPU_GetShortName(hPhysicalGpu: NvPhysicalGpuHandle, pName: *mut types::NvAPI_ShortString) -> NvAPI_Status;
     }
 
-    nvapi! {
+    nvapi_fn! {
         pub unsafe fn NvAPI_GPU_GetPartitionCount(hPhysicalGpu: NvPhysicalGpuHandle, pPartitionCount: *mut u32) -> NvAPI_Status;
     }
 
-    nvapi! {
+    nvapi_fn! {
         pub unsafe fn NvAPI_GetDriverModel(hPhysicalGpu: NvPhysicalGpuHandle, pDriverModel: *mut u32) -> NvAPI_Status;
     }
 }

--- a/sys/src/gpu/power.rs
+++ b/sys/src/gpu/power.rs
@@ -18,7 +18,7 @@ pub mod private {
 
     pub type NV_GPU_CLIENT_VOLT_RAILS_STATUS = NV_GPU_CLIENT_VOLT_RAILS_STATUS_V1;
 
-    nvapi! {
+    nvapi_fn! {
         /// Pascal only
         pub unsafe fn NvAPI_GPU_ClientVoltRailsGetStatus(hPhysicalGPU: NvPhysicalGpuHandle, pVoltageStatus: *mut NV_GPU_CLIENT_VOLT_RAILS_STATUS) -> NvAPI_Status;
     }
@@ -36,12 +36,12 @@ pub mod private {
 
     pub type NV_GPU_CLIENT_VOLT_RAILS_CONTROL = NV_GPU_CLIENT_VOLT_RAILS_CONTROL_V1;
 
-    nvapi! {
+    nvapi_fn! {
         /// Pascal only
         pub unsafe fn NvAPI_GPU_ClientVoltRailsGetControl(hPhysicalGPU: NvPhysicalGpuHandle, pVoltboostPercent: *mut NV_GPU_CLIENT_VOLT_RAILS_CONTROL) -> NvAPI_Status;
     }
 
-    nvapi! {
+    nvapi_fn! {
         /// Pascal only
         pub unsafe fn NvAPI_GPU_ClientVoltRailsSetControl(hPhysicalGPU: NvPhysicalGpuHandle, pVoltboostPercent: *const NV_GPU_CLIENT_VOLT_RAILS_CONTROL) -> NvAPI_Status;
     }
@@ -88,7 +88,7 @@ pub mod private {
 
     pub type NV_GPU_CLOCK_CLIENT_CLK_VF_POINTS_STATUS = NV_GPU_CLOCK_CLIENT_CLK_VF_POINTS_STATUS_V1;
 
-    nvapi! {
+    nvapi_fn! {
         /// Pascal only
         pub unsafe fn NvAPI_GPU_ClockClientClkVfPointsGetStatus(hPhysicalGPU: NvPhysicalGpuHandle, pVfpCurve: *mut NV_GPU_CLOCK_CLIENT_CLK_VF_POINTS_STATUS) -> NvAPI_Status;
     }
@@ -124,7 +124,7 @@ pub mod private {
     nvversion! { NV_GPU_POWER_INFO_VER_1(NV_GPU_POWER_INFO_V1 = 4 * 2 + 4 * (4 * 11), 1) }
     nvversion! { NV_GPU_POWER_INFO_VER = NV_GPU_POWER_INFO_VER_1 }
 
-    nvapi! {
+    nvapi_fn! {
         pub unsafe fn NvAPI_GPU_ClientPowerPoliciesGetInfo(hPhysicalGPU: NvPhysicalGpuHandle, pPowerInfo: *mut NV_GPU_POWER_INFO) -> NvAPI_Status;
     }
 
@@ -150,11 +150,11 @@ pub mod private {
     nvversion! { NV_GPU_POWER_STATUS_VER_1(NV_GPU_POWER_STATUS_V1 = 4 * 2 + 4 * (4 * 4), 1) }
     nvversion! { NV_GPU_POWER_STATUS_VER = NV_GPU_POWER_STATUS_VER_1 }
 
-    nvapi! {
+    nvapi_fn! {
         pub unsafe fn NvAPI_GPU_ClientPowerPoliciesGetStatus(hPhysicalGPU: NvPhysicalGpuHandle, pPowerStatus: *mut NV_GPU_POWER_STATUS) -> NvAPI_Status;
     }
 
-    nvapi! {
+    nvapi_fn! {
         pub unsafe fn NvAPI_GPU_ClientPowerPoliciesSetStatus(hPhysicalGPU: NvPhysicalGpuHandle, pPowerStatus: *const NV_GPU_POWER_STATUS) -> NvAPI_Status;
     }
 
@@ -180,7 +180,7 @@ pub mod private {
     nvversion! { NV_GPU_POWER_TOPO_VER_1(NV_GPU_POWER_TOPO_V1 = 4 * 2 + 4 * (4 * 4), 1) }
     nvversion! { NV_GPU_POWER_TOPO_VER = NV_GPU_POWER_TOPO_VER_1 }
 
-    nvapi! {
+    nvapi_fn! {
         pub unsafe fn NvAPI_GPU_ClientPowerTopologyGetStatus(hPhysicalGPU: NvPhysicalGpuHandle, pPowerTopo: *mut NV_GPU_POWER_TOPO) -> NvAPI_Status;
     }
 
@@ -225,7 +225,7 @@ pub mod private {
     nvversion! { NV_GPU_PERF_INFO_VER_1(NV_GPU_PERF_INFO_V1 = 76, 1) }
     nvversion! { NV_GPU_PERF_INFO_VER = NV_GPU_PERF_INFO_VER_1 }
 
-    nvapi! {
+    nvapi_fn! {
         pub unsafe fn NvAPI_GPU_PerfPoliciesGetInfo(hPhysicalGPU: NvPhysicalGpuHandle, pPerfInfo: *mut NV_GPU_PERF_INFO) -> NvAPI_Status;
     }
 
@@ -258,7 +258,7 @@ pub mod private {
     nvversion! { NV_GPU_PERF_STATUS_VER_1(NV_GPU_PERF_STATUS_V1 = 0x550, 1) }
     nvversion! { NV_GPU_PERF_STATUS_VER = NV_GPU_PERF_STATUS_VER_1 }
 
-    nvapi! {
+    nvapi_fn! {
         pub unsafe fn NvAPI_GPU_PerfPoliciesGetStatus(hPhysicalGPU: NvPhysicalGpuHandle, pPerfStatus: *mut NV_GPU_PERF_STATUS) -> NvAPI_Status;
     }
 
@@ -279,12 +279,12 @@ pub mod private {
     nvversion! { NV_VOLT_STATUS_VER_1(NV_VOLT_STATUS_V1 = 140, 1) }
     nvversion! { NV_VOLT_STATUS_VER = NV_VOLT_STATUS_VER_1 }
 
-    nvapi! {
+    nvapi_fn! {
         /// Maxwell only
         pub unsafe fn NvAPI_GPU_GetVoltageDomainsStatus(hPhysicalGPU: NvPhysicalGpuHandle, pVoltStatus: *mut NV_VOLT_STATUS) -> NvAPI_Status;
     }
 
-    nvapi! {
+    nvapi_fn! {
         /// Maxwell only
         pub unsafe fn NvAPI_GPU_GetVoltageStep(hPhysicalGPU: NvPhysicalGpuHandle, pVoltStep: *mut NV_VOLT_STATUS) -> NvAPI_Status;
     }
@@ -313,7 +313,7 @@ pub mod private {
     nvversion! { NV_VOLT_TABLE_VER_1(NV_VOLT_TABLE_V1 = 0x40cc, 1) }
     nvversion! { NV_VOLT_TABLE_VER = NV_VOLT_TABLE_VER_1 }
 
-    nvapi! {
+    nvapi_fn! {
         /// Maxwell only
         pub unsafe fn NvAPI_GPU_GetVoltages(hPhysicalGPU: NvPhysicalGpuHandle, pVolts: *mut NV_VOLT_TABLE) -> NvAPI_Status;
     }

--- a/sys/src/gpu/pstate.rs
+++ b/sys/src/gpu/pstate.rs
@@ -69,7 +69,7 @@ impl UtilizationDomain {
 
 nvversion! { NV_GPU_DYNAMIC_PSTATES_INFO_EX_VER(NV_GPU_DYNAMIC_PSTATES_INFO_EX = 4 * 2 + (4 * 2) * NVAPI_MAX_GPU_UTILIZATIONS, 1) }
 
-nvapi! {
+nvapi_fn! {
     pub type GPU_GetDynamicPstatesInfoExFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pDynamicPstatesInfoEx: *mut NV_GPU_DYNAMIC_PSTATES_INFO_EX) -> NvAPI_Status;
 
     /// This API retrieves the NV_GPU_DYNAMIC_PSTATES_INFO_EX structure for the specified physical GPU.
@@ -112,7 +112,7 @@ nvenum_display! {
     PstateId => _
 }
 
-nvapi! {
+nvapi_fn! {
     pub type GPU_GetCurrentPstateFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pCurrentPstate: *mut NV_GPU_PERF_PSTATE_ID) -> NvAPI_Status;
 
     /// This function retrieves the current performance state (P-State).
@@ -296,7 +296,7 @@ nvversion! { NV_GPU_PERF_PSTATES20_INFO_VER2(NV_GPU_PERF_PSTATES20_INFO_V2 = NV_
 nvversion! { NV_GPU_PERF_PSTATES20_INFO_VER3(NV_GPU_PERF_PSTATES20_INFO_V2 = NV_GPU_PERF_PSTATES20_INFO_V2_SIZE, 3) }
 nvversion! { NV_GPU_PERF_PSTATES20_INFO_VER = NV_GPU_PERF_PSTATES20_INFO_VER3 }
 
-nvapi! {
+nvapi_fn! {
     pub type GPU_GetPstates20Fn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, pPstatesInfo: *mut NV_GPU_PERF_PSTATES20_INFO) -> NvAPI_Status;
 
     /// This API retrieves all performance states (P-States) 2.0 information.
@@ -318,7 +318,7 @@ nvapi! {
 pub mod private {
     use crate::status::NvAPI_Status;
 
-    nvapi! {
+    nvapi_fn! {
         pub type GPU_SetPstates20Fn = extern "C" fn(hPhysicalGPU: super::NvPhysicalGpuHandle, pPstatesInfo: *const super::NV_GPU_PERF_PSTATES20_INFO) -> NvAPI_Status;
 
         /// Undocumented private API

--- a/sys/src/gpu/thermal.rs
+++ b/sys/src/gpu/thermal.rs
@@ -99,7 +99,7 @@ nvversion! { NV_GPU_THERMAL_SETTINGS_VER_1(NV_GPU_THERMAL_SETTINGS_V1 = NV_GPU_T
 nvversion! { NV_GPU_THERMAL_SETTINGS_VER_2(NV_GPU_THERMAL_SETTINGS_V2 = NV_GPU_THERMAL_SETTINGS_V1_SIZE, 2) }
 nvversion! { NV_GPU_THERMAL_SETTINGS_VER = NV_GPU_THERMAL_SETTINGS_VER_2 }
 
-nvapi! {
+nvapi_fn! {
     pub type GPU_GetThermalSettingsFn = extern "C" fn(hPhysicalGPU: NvPhysicalGpuHandle, sensorIndex: u32, pThermalSettings: *mut NV_GPU_THERMAL_SETTINGS) -> NvAPI_Status;
 
     /// This function retrieves the thermal information of all thermal sensors or specific thermal sensor associated with the selected GPU.
@@ -145,7 +145,7 @@ pub mod private {
     nvversion! { NV_GPU_THERMAL_INFO_VER_2(NV_GPU_THERMAL_INFO_V2 = NV_GPU_THERMAL_INFO_V2_SIZE, 2) }
     nvversion! { NV_GPU_THERMAL_INFO_VER = NV_GPU_THERMAL_INFO_VER_2 }
 
-    nvapi! {
+    nvapi_fn! {
         pub unsafe fn NvAPI_GPU_ClientThermalPoliciesGetInfo(hPhysicalGPU: NvPhysicalGpuHandle, pThermalInfo: *mut NV_GPU_THERMAL_INFO) -> NvAPI_Status;
     }
 
@@ -174,11 +174,11 @@ pub mod private {
     nvversion! { NV_GPU_CLIENT_THERMAL_POLICIES_STATUS_VER_2(NV_GPU_CLIENT_THERMAL_POLICIES_STATUS_V2 = NV_GPU_CLIENT_THERMAL_POLICIES_STATUS_V2_SIZE, 2) }
     nvversion! { NV_GPU_CLIENT_THERMAL_POLICIES_STATUS_VER = NV_GPU_CLIENT_THERMAL_POLICIES_STATUS_VER_2 }
 
-    nvapi! {
+    nvapi_fn! {
         pub unsafe fn NvAPI_GPU_ClientThermalPoliciesGetStatus(hPhysicalGPU: NvPhysicalGpuHandle, pThermalLimit: *mut NV_GPU_CLIENT_THERMAL_POLICIES_STATUS) -> NvAPI_Status;
     }
 
-    nvapi! {
+    nvapi_fn! {
         pub unsafe fn NvAPI_GPU_ClientThermalPoliciesSetStatus(hPhysicalGPU: NvPhysicalGpuHandle, pThermalLimit: *const NV_GPU_CLIENT_THERMAL_POLICIES_STATUS) -> NvAPI_Status;
     }
 }

--- a/sys/src/i2c.rs
+++ b/sys/src/i2c.rs
@@ -156,7 +156,7 @@ nvversion! { NV_I2C_INFO_VER2(NV_I2C_INFO_V2 = NV_I2C_INFO_V2_SIZE, 2) }
 nvversion! { NV_I2C_INFO_VER3(NV_I2C_INFO_V3 = NV_I2C_INFO_V3_SIZE, 3) }
 nvversion! { NV_I2C_INFO_VER = NV_I2C_INFO_VER3 }
 
-nvapi! {
+nvapi_fn! {
     pub type NvAPI_I2CReadFn = extern "C" fn(hPhysicalGpu: NvPhysicalGpuHandle, pI2cInfo: *mut NV_I2C_INFO) -> NvAPI_Status;
 
     /// This function reads the data buffer from the I2C port.
@@ -181,7 +181,7 @@ nvapi! {
     pub unsafe fn NvAPI_I2CRead;
 }
 
-nvapi! {
+nvapi_fn! {
     pub type NvAPI_I2CWriteFn = extern "C" fn(hPhysicalGpu: NvPhysicalGpuHandle, pI2cInfo: *mut NV_I2C_INFO) -> NvAPI_Status;
 
     /// This function writes the data buffer to the I2C port.
@@ -260,14 +260,14 @@ pub mod private {
     nvversion! { NV_I2C_INFO_EX_VER3(NV_I2C_INFO_EX_V3 = NV_I2C_INFO_EX_V3_SIZE, 3) }
     nvversion! { NV_I2C_INFO_EX_VER = NV_I2C_INFO_EX_VER3 }
 
-    nvapi! {
+    nvapi_fn! {
         pub type NvAPI_I2CReadExFn = extern "C" fn(hPhysicalGpu: NvPhysicalGpuHandle, pI2cInfo: *mut NV_I2C_INFO_EX, pData: *mut u32) -> NvAPI_Status;
 
         /// Undocumented function. `pData` is often `{ 1, 0 }`?
         pub unsafe fn NvAPI_I2CReadEx;
     }
 
-    nvapi! {
+    nvapi_fn! {
         pub type NvAPI_I2CWriteExFn = extern "C" fn(hPhysicalGpu: NvPhysicalGpuHandle, pI2cInfo: *mut NV_I2C_INFO_EX, pData: *mut u32) -> NvAPI_Status;
 
         /// Undocumented function. `pData` is often `{ 1, 0 }`?

--- a/sys/src/macros.rs
+++ b/sys/src/macros.rs
@@ -1,3 +1,4 @@
+#[macro_export]
 macro_rules! nv_declare_handle {
     (
         $(#[$meta:meta])*
@@ -15,6 +16,7 @@ macro_rules! nv_declare_handle {
     };
 }
 
+#[macro_export]
 macro_rules! nvinherit {
     (
         $v2:ident($id:ident: $v1:ty)
@@ -35,6 +37,7 @@ macro_rules! nvinherit {
     };
 }
 
+#[macro_export]
 macro_rules! nvstruct {
     (
         $(#[$meta:meta])*
@@ -57,6 +60,7 @@ macro_rules! nvstruct {
     };
 }
 
+#[macro_export]
 macro_rules! nvenum {
     (
         $(#[$meta:meta])*
@@ -116,6 +120,7 @@ macro_rules! nvenum {
     };
 }
 
+#[macro_export]
 macro_rules! nvbits {
     (
         $(#[$meta:meta])*
@@ -161,6 +166,7 @@ macro_rules! nvbits {
     };
 }
 
+#[macro_export]
 macro_rules! nvenum_display {
     ($enum:ident => _) => {
         impl ::std::fmt::Display for $enum {
@@ -199,7 +205,8 @@ macro_rules! nvenum_display {
     };
 }
 
-macro_rules! nvapi {
+#[macro_export]
+macro_rules! nvapi_fn {
     (
         $(#[$meta:meta])*
         pub unsafe fn $fn:ident($($arg:ident: $arg_ty:ty),*) -> $ret:ty;
@@ -222,7 +229,7 @@ macro_rules! nvapi {
     ) => {
         pub type $name = extern "C" fn($($arg: $arg_ty),*) -> $ret;
 
-        nvapi! {
+        nvapi_fn! {
             $(#[$meta])*
             pub unsafe fn $fn($($arg: $arg_ty),*) -> $ret;
         }
@@ -230,6 +237,7 @@ macro_rules! nvapi {
 }
 
 // No `const fn` yet :(
+#[macro_export]
 macro_rules! nvversion {
     ($name:ident($struct:ident = $sz:expr, $ver:expr)) => {
         pub const $name: u32 = ($sz) as u32 | ($ver as u32) << 16;

--- a/sys/src/nvapi.rs
+++ b/sys/src/nvapi.rs
@@ -67,7 +67,7 @@ pub(crate) fn query_interface(id: u32, cache: &AtomicUsize) -> crate::Result<usi
     }
 }
 
-nvapi! {
+nvapi_fn! {
     pub type InitializeFn = extern "C" fn() -> NvAPI_Status;
 
     /// This function initializes the NvAPI library (if not already initialized) but always increments the ref-counter.
@@ -75,7 +75,7 @@ nvapi! {
     pub unsafe fn NvAPI_Initialize;
 }
 
-nvapi! {
+nvapi_fn! {
     pub type UnloadFn = extern "C" fn() -> NvAPI_Status;
 
     /// Decrements the ref-counter and when it reaches ZERO, unloads NVAPI library.
@@ -99,14 +99,14 @@ nvapi! {
     pub unsafe fn NvAPI_Unload;
 }
 
-nvapi! {
+nvapi_fn! {
     pub type GetErrorMessageFn = extern "C" fn(nr: NvAPI_Status, szDesc: *mut types::NvAPI_ShortString) -> NvAPI_Status;
 
     /// This function converts an NvAPI error code into a null terminated string.
     pub unsafe fn NvAPI_GetErrorMessage;
 }
 
-nvapi! {
+nvapi_fn! {
     pub type GetInterfaceVersionStringFn = extern "C" fn(szDesc: *mut types::NvAPI_ShortString) -> NvAPI_Status;
 
     /// This function returns a string describing the version of the NvAPI library.


### PR DESCRIPTION
If `nvapi_sys` is used directly, I have to copy the macro on my code because not all functions are wrapped. `nvapi!` rename to `nvapi_fn!`